### PR TITLE
remake EXP candy

### DIFF
--- a/PixelmonServerManager/src/main/java/org/kyoee01/pixelmon/server/listeners/ListenerManager.java
+++ b/PixelmonServerManager/src/main/java/org/kyoee01/pixelmon/server/listeners/ListenerManager.java
@@ -1,8 +1,7 @@
 package org.Kyoee01.pixelmon.server.listeners;
 
 import com.pixelmonmod.pixelmon.Pixelmon;
-import org.bukkit.Bukkit;
-import org.bukkit.event.Listener;
+import org.Kyoee01.pixelmon.server.listeners.forge.RamakeExpCandy;
 import org.bukkit.plugin.Plugin;
 
 public class ListenerManager {
@@ -11,6 +10,7 @@ public class ListenerManager {
             Forge Event register here - evnet = Instance [Ex) Pixelmon.EVENT_BUS.register(new ExampleEvent())]
             Pixelmon.EVENT_BUS.register(event);
          */
+        Pixelmon.EVENT_BUS.register(new RamakeExpCandy());
     }
 
     public static void registerBukkitEvents(Plugin plugin){

--- a/PixelmonServerManager/src/main/java/org/kyoee01/pixelmon/server/listeners/forge/RamakeExpCandy.java
+++ b/PixelmonServerManager/src/main/java/org/kyoee01/pixelmon/server/listeners/forge/RamakeExpCandy.java
@@ -3,7 +3,9 @@ package org.Kyoee01.pixelmon.server.listeners.forge;
 import com.pixelmonmod.pixelmon.api.enums.ExperienceGainType;
 import com.pixelmonmod.pixelmon.api.events.ExperienceGainEvent;
 import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.util.text.LanguageMap;
 import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import org.bukkit.ChatColor;
 
@@ -44,12 +46,12 @@ public class RamakeExpCandy {
         if (!e.isCanceled() && player != null){
             String name;
             if (e.pokemon.getPokemon().getNickname().equals("")){
-                name = "pixelmon."+e.pokemon.getPokemon().getSpecies().getName().toLowerCase();
+                name = new TranslationTextComponent("pixelmon."+e.pokemon.getPokemon().getSpecies().getName().toLowerCase()).getUnformattedComponentText();
             } else {
                 name = e.pokemon.getPokemon().getNickname();
             }
             player.sendMessage(new StringTextComponent(ChatColor.translateAlternateColorCodes('&',
-                            prefix +"&a&l"+ name +" &f이(가) &e"+format.format(e.getExperience())+"EXP &f를 얻었습니다.")),
+                            prefix +"&a"+ name +" &f이(가) &e"+format.format(e.getExperience())+"EXP &f를 얻었습니다.")),
                     UUID.randomUUID());
         }
     }

--- a/PixelmonServerManager/src/main/java/org/kyoee01/pixelmon/server/listeners/forge/RamakeExpCandy.java
+++ b/PixelmonServerManager/src/main/java/org/kyoee01/pixelmon/server/listeners/forge/RamakeExpCandy.java
@@ -1,0 +1,56 @@
+package org.Kyoee01.pixelmon.server.listeners.forge;
+
+import com.pixelmonmod.pixelmon.api.enums.ExperienceGainType;
+import com.pixelmonmod.pixelmon.api.events.ExperienceGainEvent;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import org.bukkit.ChatColor;
+
+import java.text.DecimalFormat;
+import java.util.UUID;
+
+public class RamakeExpCandy {
+
+    private static DecimalFormat format = new DecimalFormat("###,###");
+    private static String prefix = "&f&l[&6&lSERVER&f&l] &f";
+
+    @SubscribeEvent
+    public void onUseExpCandyEvent(ExperienceGainEvent e) {
+        Integer needExp = e.pokemon.getExpToNextLevel();
+        ServerPlayerEntity player = e.pokemon.getPlayerOwner();
+        ExperienceGainType ItemType = e.getType();
+        if (ItemType.name().contains("EXP_CANDY")){
+            float ExpPer = 0;
+            if (ItemType.equals(ExperienceGainType.EXTRA_SMALL_EXP_CANDY)){
+                ExpPer = 2.5f;
+            } else if (ItemType.equals(ExperienceGainType.SMALL_EXP_CANDY)){
+                ExpPer = 7.5f;
+            } else if (ItemType.equals(ExperienceGainType.MEDIUM_EXP_CANDY)){
+                ExpPer = 15.0f;
+            } else if (ItemType.equals(ExperienceGainType.LARGE_EXP_CANDY)){
+                ExpPer = 30.0f;
+            } else if (ItemType.equals(ExperienceGainType.EXTRA_LARGE_EXP_CANDY)){
+                ExpPer = 60.0f;
+            }
+            e.setExperience(Math.round(needExp*ExpPer/100.0f+1.0f));
+        }
+        else if (e.getType().name().contains("RARE_CANDY")){
+            if(e.getExperience() != needExp){
+                e.setCanceled(true);
+            }
+        }
+
+        if (!e.isCanceled() && player != null){
+            String name;
+            if (e.pokemon.getPokemon().getNickname().equals("")){
+                name = "pixelmon."+e.pokemon.getPokemon().getSpecies().getName().toLowerCase();
+            } else {
+                name = e.pokemon.getPokemon().getNickname();
+            }
+            player.sendMessage(new StringTextComponent(ChatColor.translateAlternateColorCodes('&',
+                            prefix +"&a&l"+ name +" &f이(가) &e"+format.format(e.getExperience())+"EXP &f를 얻었습니다.")),
+                    UUID.randomUUID());
+        }
+    }
+}


### PR DESCRIPTION
### 추가

- 경험치 사탕의 리메이크
> 경험치 사탕이 각각
> ### 경험사탕XS : 
> 100 EXP -> 다음 레벨의 0.75%
> ### 경험사탕S : 
> 800 EXP -> 다음 레벨의 1.75%
> ### 경험사탕M: 
> 3000 EXP -> 다음 레벨의 4.5%
> ### 경험사탕L: 
> 10000 EXP -> 다음 레벨의 12.5%
> ### 경험사탕XL: 
> 30000 EXP -> 다음 레벨의 30.0%